### PR TITLE
#35 refactor(recipes): allineamento modulo Recipe agli standard robusti

### DIFF
--- a/backend/prisma/migrations/20251126130430_refactor_recipe_module/migration.sql
+++ b/backend/prisma/migrations/20251126130430_refactor_recipe_module/migration.sql
@@ -1,0 +1,33 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `unit` on the `recipe_ingredients` table. The data in that column could be lost. The data in that column will be cast from `VarChar(191)` to `VarChar(20)`.
+  - You are about to drop the column `note` on the `recipes` table. All the data in the column will be lost.
+  - Added the required column `updatedAt` to the `recipe_ingredients` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `recipe_ingredients` ADD COLUMN `costPerUnit` DECIMAL(10, 4) NULL DEFAULT 0.0000,
+    ADD COLUMN `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    ADD COLUMN `isOptional` BOOLEAN NULL DEFAULT false,
+    ADD COLUMN `notes` TEXT NULL,
+    ADD COLUMN `preparationStep` INTEGER NULL DEFAULT 1,
+    ADD COLUMN `totalCost` DECIMAL(10, 4) NULL DEFAULT 0.0000,
+    ADD COLUMN `updatedAt` DATETIME(3) NOT NULL,
+    MODIFY `quantity` DECIMAL(12, 3) NOT NULL,
+    MODIFY `unit` VARCHAR(20) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `recipes` DROP COLUMN `note`,
+    ADD COLUMN `active` BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN `chefNotes` TEXT NULL,
+    ADD COLUMN `cookingTime` INTEGER NULL DEFAULT 0,
+    ADD COLUMN `createdBy` INTEGER NULL,
+    ADD COLUMN `difficulty` ENUM('easy', 'medium', 'hard') NOT NULL DEFAULT 'medium',
+    ADD COLUMN `instructions` TEXT NULL,
+    ADD COLUMN `portionSize` DECIMAL(8, 2) NULL DEFAULT 1.00,
+    ADD COLUMN `preparationTime` INTEGER NULL DEFAULT 0,
+    ADD COLUMN `totalCost` DECIMAL(10, 4) NULL DEFAULT 0.0000,
+    ADD COLUMN `version` INTEGER NULL DEFAULT 1,
+    MODIFY `name` VARCHAR(200) NOT NULL,
+    MODIFY `description` TEXT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -145,7 +145,7 @@ model Product {
   ingredients      ProductIngredient[]
   orderItems       OrderItem[]
   recipeId         Int?
-  recipe           Recipe?   @relation(fields: [recipeId], references: [id])
+  recipe           Recipe?   @relation("RecipeProducts", fields: [recipeId], references: [id])
   categoryId       Int
   category         Category  @relation(fields: [categoryId], references: [id])
 
@@ -175,11 +175,6 @@ model Order {
   total              Float         @default(0)
   createdAt          DateTime      @default(now())
   updatedAt          DateTime      @updatedAt
-
-  items              OrderItem[]
-  table              Table?        @relation(fields: [tableId], references: [id])
-
-  // Campi aggiuntivi
   userId             Int?
   customerName       String?       @db.VarChar(200)
   customerPhone      String?       @db.VarChar(20)
@@ -200,6 +195,9 @@ model Order {
   heldAt             DateTime?     @db.Timestamp(0)
   user               User?         @relation(fields: [userId], references: [id])
   promotion          Promotion?    @relation(fields: [promotionId], references: [id])
+
+  items              OrderItem[]
+  table              Table?        @relation(fields: [tableId], references: [id])
 
   @@map("orders")
 }
@@ -399,35 +397,57 @@ enum PurchaseOrderStatus {
 // ===== RECIPES =====
 
 model Recipe {
-  id          Int      @id @default(autoincrement())
-  name        String
-  description String?
-  note        String?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id              Int      @id @default(autoincrement())
+  name            String   @db.VarChar(200)
+  description     String?  @db.Text
+  portionSize     Decimal? @db.Decimal(8,2) @default(1.00)
+  preparationTime Int?     @default(0)
+  cookingTime     Int?     @default(0)
+  difficulty      Difficulty @default(medium)
+  instructions    String?  @db.Text
+  chefNotes       String?  @db.Text
+  totalCost       Decimal? @db.Decimal(10,4) @default(0.0000)
+  active          Boolean  @default(true)
+  version         Int?     @default(1)
+  createdBy       Int?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
-  ingredients RecipeIngredient[]
-  products    Product[]
+  ingredients     RecipeIngredient[]
+  products        Product[] @relation("RecipeProducts") // Relazione con Product
 
   @@unique([name])
   @@map("recipes")
 }
 
-model RecipeIngredient {
-  id           Int        @id @default(autoincrement())
-  recipeId     Int
-  ingredientId Int
-  quantity     Float
-  unit         String
+enum Difficulty {
+  easy
+  medium
+  hard
+}
 
-  recipe       Recipe     @relation(fields: [recipeId], references: [id])
-  ingredient   Ingredient @relation(fields: [ingredientId], references: [id])
+model RecipeIngredient {
+  id               Int      @id @default(autoincrement())
+  recipeId         Int
+  ingredientId     Int
+  quantity         Decimal  @db.Decimal(12,3)
+  unit             String   @db.VarChar(20)
+  notes            String?  @db.Text
+  isOptional       Boolean? @default(false)
+  preparationStep  Int?     @default(1)
+  costPerUnit      Decimal? @db.Decimal(10,4) @default(0.0000)
+  totalCost        Decimal? @db.Decimal(10,4) @default(0.0000)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  recipe           Recipe   @relation(fields: [recipeId], references: [id])
+  ingredient       Ingredient @relation(fields: [ingredientId], references: [id])
 
   @@unique([recipeId, ingredientId])
   @@map("recipe_ingredients")
 }
 
-// ===== RECIPES =====
+// ===== CATEGORIES =====
 
 model Category {
   id          Int      @id @default(autoincrement())

--- a/backend/src/modules/recipes/controllers/recipeIngredientsController.ts
+++ b/backend/src/modules/recipes/controllers/recipeIngredientsController.ts
@@ -1,29 +1,73 @@
+
 import { Request, Response } from 'express';
 import { RecipeIngredientsService } from '../services/recipeIngredientsService';
 
-export const RecipeIngredientsController = {
-  async getAll(req: Request, res: Response) {
-    const items = await RecipeIngredientsService.getAll();
-    res.json(items);
-  },
-  async getById(req: Request, res: Response) {
-    const { id } = req.params;
-    const item = await RecipeIngredientsService.getById(Number(id));
-    if (!item) return res.status(404).json({ error: 'RecipeIngredient not found' });
-    res.json(item);
-  },
-  async create(req: Request, res: Response) {
-    const item = await RecipeIngredientsService.create(req.body);
-    res.status(201).json(item);
-  },
-  async update(req: Request, res: Response) {
-    const { id } = req.params;
-    const item = await RecipeIngredientsService.update(Number(id), req.body);
-    res.json(item);
-  },
-  async delete(req: Request, res: Response) {
-    const { id } = req.params;
-    await RecipeIngredientsService.delete(Number(id));
-    res.status(204).send();
+export class RecipeIngredientsController {
+  static async getAll(req: Request, res: Response) {
+    try {
+      const { recipeId, ingredientId, search, isOptional, preparationStep, page, pageSize } = req.query;
+      // Conversione tipi
+      const filters = {
+        recipeId: recipeId ? Number(recipeId) : undefined,
+        ingredientId: ingredientId ? Number(ingredientId) : undefined,
+        search: typeof search === 'string' ? search : undefined,
+        isOptional: typeof isOptional === 'string' ? (isOptional === 'true' ? true : isOptional === 'false' ? false : isOptional) : undefined,
+        preparationStep: preparationStep ? Number(preparationStep) : undefined,
+        page: page ? Number(page) : 1,
+        pageSize: pageSize ? Number(pageSize) : 20
+      };
+      const result = await RecipeIngredientsService.getAll(filters);
+      res.json(result);
+    } catch (error: any) {
+      res.status(500).json({ error: error.message });
+    }
   }
-};
+
+  static async getById(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const item = await RecipeIngredientsService.getById(Number(id));
+      res.json(item);
+    } catch (error: any) {
+      res.status(404).json({ error: error.message });
+    }
+  }
+
+  static async create(req: Request, res: Response) {
+    try {
+      const item = await RecipeIngredientsService.create(req.body);
+      res.status(201).json(item);
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  }
+
+  static async update(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const item = await RecipeIngredientsService.update(Number(id), req.body);
+      res.json(item);
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  }
+
+  static async delete(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      await RecipeIngredientsService.delete(Number(id));
+      res.json({ message: 'Ingrediente ricetta eliminato', id: Number(id) });
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  }
+
+  static async getStats(req: Request, res: Response) {
+    try {
+      const stats = await RecipeIngredientsService.getStats();
+      res.json(stats);
+    } catch (error: any) {
+      res.status(500).json({ error: error.message });
+    }
+  }
+}

--- a/backend/src/modules/recipes/controllers/recipesController.ts
+++ b/backend/src/modules/recipes/controllers/recipesController.ts
@@ -1,29 +1,79 @@
 import { Request, Response } from 'express';
 import { RecipesService } from '../services/recipesService';
 
-export const RecipesController = {
-  async getAll(req: Request, res: Response) {
-    const recipes = await RecipesService.getAll();
-    res.json(recipes);
-  },
-  async getById(req: Request, res: Response) {
-    const { id } = req.params;
-    const recipe = await RecipesService.getById(Number(id));
-    if (!recipe) return res.status(404).json({ error: 'Recipe not found' });
-    res.json(recipe);
-  },
-  async create(req: Request, res: Response) {
-    const recipe = await RecipesService.create(req.body);
-    res.status(201).json(recipe);
-  },
-  async update(req: Request, res: Response) {
-    const { id } = req.params;
-    const recipe = await RecipesService.update(Number(id), req.body);
-    res.json(recipe);
-  },
-  async delete(req: Request, res: Response) {
-    const { id } = req.params;
-    await RecipesService.delete(Number(id));
-    res.status(204).send();
+export class RecipesController {
+    static async getAvailableProducts(req: Request, res: Response) {
+      try {
+        const products = await RecipesService.getAvailableProducts();
+        res.json({ products });
+      } catch (error: any) {
+        res.status(500).json({ error: error.message });
+      }
+    }
+  static async getAll(req: Request, res: Response) {
+    try {
+      const { search, active, difficulty, productId, page, pageSize } = req.query;
+      // Conversione tipi
+      const filters = {
+        search: typeof search === 'string' ? search : undefined,
+        active: typeof active === 'string' ? (active === 'true' ? true : active === 'false' ? false : active) : undefined,
+        difficulty: typeof difficulty === 'string' ? difficulty : undefined,
+        productId: productId ? Number(productId) : undefined,
+        page: page ? Number(page) : 1,
+        pageSize: pageSize ? Number(pageSize) : 20
+      };
+      const result = await RecipesService.getAll(filters);
+      res.json(result);
+    } catch (error: any) {
+      res.status(500).json({ error: error.message });
+    }
   }
-};
+
+  static async getById(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const recipe = await RecipesService.getById(Number(id));
+      res.json(recipe);
+    } catch (error: any) {
+      res.status(404).json({ error: error.message });
+    }
+  }
+
+  static async create(req: Request, res: Response) {
+    try {
+      const recipe = await RecipesService.create(req.body);
+      res.status(201).json(recipe);
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  }
+
+  static async update(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const recipe = await RecipesService.update(Number(id), req.body);
+      res.json(recipe);
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  }
+
+  static async delete(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const result = await RecipesService.delete(Number(id));
+      res.json(result);
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  }
+
+  static async getStats(req: Request, res: Response) {
+    try {
+      const stats = await RecipesService.getStats();
+      res.json(stats);
+    } catch (error: any) {
+      res.status(500).json({ error: error.message });
+    }
+  }
+}

--- a/backend/src/modules/recipes/routes/recipeIngredientsRoutes.ts
+++ b/backend/src/modules/recipes/routes/recipeIngredientsRoutes.ts
@@ -13,7 +13,9 @@ function validateRecipeIngredient(req: Request, res: Response, next: NextFunctio
 	}
 }
 
-router.get('/', RecipeIngredientsController.getAll);
+
+router.get('/', RecipeIngredientsController.getAll); // supporta query params per filtri
+router.get('/stats', RecipeIngredientsController.getStats);
 router.get('/:id', RecipeIngredientsController.getById);
 router.post('/', validateRecipeIngredient, RecipeIngredientsController.create);
 router.put('/:id', validateRecipeIngredient, RecipeIngredientsController.update);

--- a/backend/src/modules/recipes/routes/recipesRoutes.ts
+++ b/backend/src/modules/recipes/routes/recipesRoutes.ts
@@ -13,7 +13,9 @@ function validateRecipe(req: Request, res: Response, next: NextFunction) {
 	}
 }
 
-router.get('/', RecipesController.getAll);
+router.get('/available-products', RecipesController.getAvailableProducts);
+router.get('/', RecipesController.getAll); // supporta query params per filtri
+router.get('/stats', RecipesController.getStats);
 router.get('/:id', RecipesController.getById);
 router.post('/', validateRecipe, RecipesController.create);
 router.put('/:id', validateRecipe, RecipesController.update);

--- a/backend/src/modules/recipes/services/recipeIngredientsService.ts
+++ b/backend/src/modules/recipes/services/recipeIngredientsService.ts
@@ -1,20 +1,83 @@
+
+
 import { PrismaClient } from '../../../generated/prisma/client';
 const prisma = new PrismaClient();
 
-export const RecipeIngredientsService = {
-  async getAll() {
-    return prisma.recipeIngredient.findMany({ include: { recipe: true, ingredient: true } });
-  },
-  async getById(id: number) {
-    return prisma.recipeIngredient.findUnique({ where: { id }, include: { recipe: true, ingredient: true } });
-  },
-  async create(data: any) {
+// Interfaccia per i filtri di getAll
+interface RecipeIngredientFilters {
+  recipeId?: number | undefined;
+  ingredientId?: number | undefined;
+  search?: string | undefined;
+  isOptional?: boolean | string | undefined;
+  preparationStep?: number | undefined;
+  page?: number | undefined;
+  pageSize?: number | undefined;
+}
+
+export class RecipeIngredientsService {
+  // Filtri avanzati + paginazione
+  static async getAll({ recipeId, ingredientId, search, isOptional, preparationStep, page = 1, pageSize = 20 }: RecipeIngredientFilters = {}) {
+    const where: any = {};
+    if (recipeId) where.recipeId = recipeId;
+    if (ingredientId) where.ingredientId = ingredientId;
+    if (isOptional !== undefined) where.isOptional = isOptional === true || isOptional === 'true';
+    if (preparationStep) where.preparationStep = preparationStep;
+    if (search) {
+      where.OR = [
+        { notes: { contains: search, mode: 'insensitive' } },
+        { unit: { contains: search, mode: 'insensitive' } }
+      ];
+    }
+    const skip = (page - 1) * pageSize;
+    const [items, total] = await Promise.all([
+      prisma.recipeIngredient.findMany({
+        where,
+        include: { recipe: true, ingredient: true },
+        orderBy: { preparationStep: 'asc' },
+        skip,
+        take: pageSize
+      }),
+      prisma.recipeIngredient.count({ where })
+    ]);
+    return { items, total, page, pageSize, filters: { recipeId, ingredientId, search, isOptional, preparationStep } };
+  }
+
+  static async getById(id: number) {
+    const item = await prisma.recipeIngredient.findUnique({ where: { id }, include: { recipe: true, ingredient: true } });
+    if (!item) throw new Error('Ingrediente ricetta non trovato');
+    return item;
+  }
+
+  // Create con validazione duplicati
+  static async create(data: any) {
+    // Un solo ingrediente per ricetta
+    const exists = await prisma.recipeIngredient.findFirst({
+      where: { recipeId: data.recipeId, ingredientId: data.ingredientId }
+    });
+    if (exists) throw new Error('Questo ingrediente è già presente nella ricetta');
     return prisma.recipeIngredient.create({ data });
-  },
-  async update(id: number, data: any) {
+  }
+
+  // Update con validazione duplicati
+  static async update(id: number, data: any) {
+    if (data.recipeId && data.ingredientId) {
+      const exists = await prisma.recipeIngredient.findFirst({
+        where: { recipeId: data.recipeId, ingredientId: data.ingredientId, NOT: { id } }
+      });
+      if (exists) throw new Error('Questo ingrediente è già presente nella ricetta');
+    }
     return prisma.recipeIngredient.update({ where: { id }, data });
-  },
-  async delete(id: number) {
+  }
+
+  static async delete(id: number) {
     return prisma.recipeIngredient.delete({ where: { id } });
   }
-};
+
+  // Statistiche
+  static async getStats() {
+    const total = await prisma.recipeIngredient.count();
+    const optional = await prisma.recipeIngredient.count({ where: { isOptional: true } });
+    const steps = await prisma.recipeIngredient.count({ where: { preparationStep: { not: null } } });
+    return { total, optional, withPreparationStep: steps };
+  }
+}

--- a/backend/src/modules/recipes/services/recipesService.ts
+++ b/backend/src/modules/recipes/services/recipesService.ts
@@ -1,22 +1,135 @@
-import { PrismaClient } from '../../../generated/prisma/client';
+import { PrismaClient, Difficulty } from '../../../generated/prisma/client';
+
+// Interfaccia per i filtri di getAll
+interface RecipeFilters {
+  search?: string | undefined;
+  active?: boolean | string | undefined;
+  difficulty?: Difficulty | string | undefined;
+  productId?: number | undefined;
+  page?: number | undefined;
+  pageSize?: number | undefined;
+}
 const prisma = new PrismaClient();
 
-export const RecipesService = {
-  async getAll() {
-    return prisma.recipe.findMany({ include: { ingredients: true, products: true } });
-  },
-  async getById(id: number) {
-    return prisma.recipe.findUnique({ where: { id }, include: { ingredients: true, products: true } });
-  },
-  async create(data: any) {
-    return prisma.recipe.create({ data });
-  },
-  async update(id: number, data: any) {
-    return prisma.recipe.update({ where: { id }, data });
-  },
-  async delete(id: number) {
-    // Elimina prima i collegamenti con gli ingredienti
-    await prisma.recipeIngredient.deleteMany({ where: { recipeId: id } });
-    return prisma.recipe.delete({ where: { id } });
+export class RecipesService {
+    // Prodotti disponibili per ricette
+    static async getAvailableProducts() {
+      // Prendi solo prodotti attivi NON associati a nessuna ricetta
+      const products = await prisma.product.findMany({
+        where: {
+          active: true,
+          recipeId: null // solo prodotti non associati a ricetta
+        },
+        select: {
+          id: true,
+          name: true,
+          basePrice: true
+        },
+        orderBy: { name: 'asc' }
+      });
+      return products;
+    }
+  // Filtri avanzati + paginazione
+  static async getAll({ search, active, difficulty, productId, page = 1, pageSize = 20 }: RecipeFilters = {}) {
+    const where: any = {};
+    if (search) {
+      where.OR = [
+        { name: { contains: search } },
+        { description: { contains: search } },
+        { instructions: { contains: search } }
+      ];
+    }
+    if (active !== undefined) where.active = active === true || active === 'true';
+    if (difficulty) where.difficulty = difficulty;
+    if (productId) where.products = { some: { id: productId } };
+    const skip = (page - 1) * pageSize;
+    const [recipes, total] = await Promise.all([
+      prisma.recipe.findMany({
+        where,
+        include: {
+          ingredients: { include: { ingredient: true } },
+          products: true
+        },
+        orderBy: { name: 'asc' },
+        skip,
+        take: pageSize
+      }),
+      prisma.recipe.count({ where })
+    ]);
+    // Statistiche summary
+    const summary = {
+      total,
+      active: recipes.filter(r => r.active).length,
+      inactive: recipes.filter(r => !r.active).length,
+      withProducts: recipes.filter(r => r.products.length > 0).length
+    };
+    return { recipes, total, page, pageSize, summary, filters: { search, active, difficulty, productId } };
   }
-};
+
+  // Get by ID con ingredienti/prodotti
+  static async getById(id: number) {
+    const recipe = await prisma.recipe.findUnique({
+      where: { id },
+      include: {
+        ingredients: { include: { ingredient: true } },
+        products: true
+      }
+    });
+    if (!recipe) throw new Error('Ricetta non trovata');
+    return recipe;
+  }
+
+  // Create con validazione duplicati e ingredienti associati
+  static async create(data: any) {
+    // Duplicato su nome
+    const existing = await prisma.recipe.findUnique({ where: { name: data.name } });
+    if (existing) throw new Error('Esiste già una ricetta con questo nome');
+    // Ingredienti associati
+    const { ingredients, ...recipeData } = data;
+    const recipe = await prisma.recipe.create({ data: recipeData });
+    if (Array.isArray(ingredients) && ingredients.length > 0) {
+      await Promise.all(ingredients.map((item: any) =>
+        prisma.recipeIngredient.create({
+          data: { ...item, recipeId: recipe.id }
+        })
+      ));
+    }
+    return this.getById(recipe.id);
+  }
+
+  // Update con ingredienti associati
+  static async update(id: number, data: any) {
+    // Duplicato su nome (se cambiato)
+    if (data.name) {
+      const existing = await prisma.recipe.findFirst({ where: { name: data.name, NOT: { id } } });
+      if (existing) throw new Error('Esiste già una ricetta con questo nome');
+    }
+    const { ingredients, ...recipeData } = data;
+    const recipe = await prisma.recipe.update({ where: { id }, data: recipeData });
+    if (Array.isArray(ingredients)) {
+      // Aggiorna ingredienti: elimina e ricrea
+      await prisma.recipeIngredient.deleteMany({ where: { recipeId: id } });
+      await Promise.all(ingredients.map((item: any) =>
+        prisma.recipeIngredient.create({
+          data: { ...item, recipeId: id }
+        })
+      ));
+    }
+    return this.getById(id);
+  }
+
+  // Soft delete/disattivazione
+  static async delete(id: number) {
+    await prisma.recipe.update({ where: { id }, data: { active: false } });
+    return { message: 'Ricetta disattivata', id };
+  }
+
+  // Statistiche globali
+  static async getStats() {
+    const total = await prisma.recipe.count();
+    const active = await prisma.recipe.count({ where: { active: true } });
+    const inactive = await prisma.recipe.count({ where: { active: false } });
+    const withProducts = await prisma.recipe.count({ where: { products: { some: {} } } });
+    return { total, active, inactive, withProducts };
+  }
+}

--- a/backend/src/modules/recipes/validators/recipeIngredientsValidator.ts
+++ b/backend/src/modules/recipes/validators/recipeIngredientsValidator.ts
@@ -1,8 +1,14 @@
+
 import { z } from 'zod';
 
 export const recipeIngredientSchema = z.object({
-  recipeId: z.number().int(),
-  ingredientId: z.number().int(),
-  quantity: z.number().positive(),
-  unit: z.string().min(1),
+  recipeId: z.number().int().positive(),
+  ingredientId: z.number().int().positive(),
+  quantity: z.number().min(0),
+  unit: z.string().max(20),
+  notes: z.string().max(255).optional(),
+  isOptional: z.boolean().optional(),
+  preparationStep: z.number().int().min(1).optional(),
+  costPerUnit: z.number().min(0).optional(),
+  totalCost: z.number().min(0).optional()
 });

--- a/backend/src/modules/recipes/validators/recipesValidator.ts
+++ b/backend/src/modules/recipes/validators/recipesValidator.ts
@@ -1,7 +1,30 @@
+
 import { z } from 'zod';
 
+export const recipeIngredientSchema = z.object({
+  ingredientId: z.number().int().positive(),
+  quantity: z.number().min(0),
+  unit: z.string().max(20),
+  notes: z.string().max(255).optional(),
+  isOptional: z.boolean().optional(),
+  preparationStep: z.number().int().min(1).optional(),
+  costPerUnit: z.number().min(0).optional(),
+  totalCost: z.number().min(0).optional()
+});
+
 export const recipeSchema = z.object({
-  name: z.string().min(2),
-  description: z.string().optional(),
-  note: z.string().optional(),
+  name: z.string().min(2).max(200),
+  description: z.string().max(1000).optional(),
+  portionSize: z.number().min(0.01).max(1000).optional(),
+  preparationTime: z.number().int().min(0).max(1440).optional(),
+  cookingTime: z.number().int().min(0).max(1440).optional(),
+  difficulty: z.enum(['easy', 'medium', 'hard']).optional(),
+  instructions: z.string().max(5000).optional(),
+  chefNotes: z.string().max(1000).optional(),
+  totalCost: z.number().min(0).optional(),
+  active: z.boolean().optional(),
+  version: z.number().int().min(1).optional(),
+  createdBy: z.number().int().positive().optional(),
+  note: z.string().max(1000).optional(),
+  ingredients: z.array(recipeIngredientSchema).optional()
 });


### PR DESCRIPTION
- Refactor completo di controller, service, routes e validator per Recipe e RecipeIngredient
- Gestione CRUD ricette e ingredienti associati con validazione Zod estesa
- Filtri avanzati (search, attive, difficoltà, prodotti collegati) e paginazione
- Gestione duplicati su nome ricetta e ingredienti ricetta
- Endpoint extra: /available-products, /stats, ricette per prodotto
- Risposte arricchite con summary, paginazione e statistiche
- Fix relazioni Prisma tra Product e Recipe
- Test Postman su tutti i flussi, validazione input robusta