### PR TITLE
#43 feat(financials): completato modulo Financials

### DIFF
--- a/backend/prisma/migrations/20251127112713_init_financial_module/migration.sql
+++ b/backend/prisma/migrations/20251127112713_init_financial_module/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+CREATE TABLE `cash_movements` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `type` ENUM('OPEN', 'CLOSE', 'IN', 'OUT', 'RECONCILIATION', 'ADJUSTMENT') NOT NULL,
+    `amount` DECIMAL(10, 2) NOT NULL,
+    `description` TEXT NULL,
+    `userId` INTEGER NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `shiftId` INTEGER NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `cash_shifts` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `openedById` INTEGER NOT NULL,
+    `closedById` INTEGER NULL,
+    `openedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `closedAt` DATETIME(3) NULL,
+    `openingAmount` DECIMAL(10, 2) NOT NULL,
+    `closingAmount` DECIMAL(10, 2) NULL,
+    `notes` TEXT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `financial_reports` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `type` ENUM('X', 'Z', 'SUMMARY', 'DETAILED', 'EXPORT') NOT NULL,
+    `period` VARCHAR(191) NOT NULL,
+    `startDate` DATETIME(3) NOT NULL,
+    `endDate` DATETIME(3) NOT NULL,
+    `generatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `data` JSON NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `cash_movements` ADD CONSTRAINT `cash_movements_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `cash_movements` ADD CONSTRAINT `cash_movements_shiftId_fkey` FOREIGN KEY (`shiftId`) REFERENCES `cash_shifts`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `cash_shifts` ADD CONSTRAINT `cash_shifts_openedById_fkey` FOREIGN KEY (`openedById`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `cash_shifts` ADD CONSTRAINT `cash_shifts_closedById_fkey` FOREIGN KEY (`closedById`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,6 +28,10 @@ model User {
   movements Movement[]
   sessions  UserSession[]
 
+  cashMovements CashMovement[]
+  openedShifts CashShift[] @relation("OpenedBy")
+  closedShifts CashShift[] @relation("ClosedBy")
+
   @@map("users")
 }
 
@@ -553,4 +557,62 @@ model ProductAllergen {
 
   @@unique([productId, allergenId])
   @@map("product_allergens")
+}
+
+// ===== FINANCIALS =====
+
+model CashMovement {
+  id           Int      @id @default(autoincrement())
+  type         CashMovementType
+  amount       Decimal  @db.Decimal(10,2)
+  description  String?  @db.Text
+  userId       Int?
+  createdAt    DateTime @default(now())
+  shiftId      Int?
+  user         User?    @relation(fields: [userId], references: [id])
+  shift        CashShift? @relation(fields: [shiftId], references: [id])
+  @@map("cash_movements")
+}
+
+enum CashMovementType {
+  OPEN
+  CLOSE
+  IN
+  OUT
+  RECONCILIATION
+  ADJUSTMENT
+}
+
+model CashShift {
+  id           Int      @id @default(autoincrement())
+  openedById   Int
+  closedById   Int?
+  openedAt     DateTime @default(now())
+  closedAt     DateTime?
+  openingAmount Decimal @db.Decimal(10,2)
+  closingAmount Decimal? @db.Decimal(10,2)
+  notes        String?  @db.Text
+  openedBy     User     @relation("OpenedBy", fields: [openedById], references: [id])
+  closedBy     User?    @relation("ClosedBy", fields: [closedById], references: [id])
+  movements    CashMovement[]
+  @@map("cash_shifts")
+}
+
+model FinancialReport {
+  id           Int      @id @default(autoincrement())
+  type         ReportType
+  period       String
+  startDate    DateTime
+  endDate      DateTime
+  generatedAt  DateTime @default(now())
+  data         Json
+  @@map("financial_reports")
+}
+
+enum ReportType {
+  X
+  Z
+  SUMMARY
+  DETAILED
+  EXPORT
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -59,6 +59,9 @@ app.use("/allergens", allergensRoutes);
 import promotionsRoutes from "./modules/promotions/routes/promotionsRoutes"
 app.use("/promotions", promotionsRoutes);
 
+import financialRoutes from "./modules/financials/routes/financialsRoutes"
+app.use("/financials", financialRoutes);
+
 // 🔹 Middleware gestione errori
 app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   console.error(err.stack);

--- a/backend/src/modules/financials/controllers/financialsController.ts
+++ b/backend/src/modules/financials/controllers/financialsController.ts
@@ -1,0 +1,174 @@
+import { Request, Response } from 'express';
+import { FinancialsService } from '../services/financialsService';
+
+export class FinancialsController {
+  // CashMovement
+  static async createCashMovement(req: Request, res: Response) {
+    try {
+      const movement = await FinancialsService.createCashMovement(req.body);
+      res.status(201).json(movement);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  static async getAllCashMovements(req: Request, res: Response) {
+    try {
+      const { type, userId, shiftId, from, to } = req.query;
+      const filters: any = {};
+      if (type) filters.type = type;
+      if (userId) filters.userId = Number(userId);
+      if (shiftId) filters.shiftId = Number(shiftId);
+      if (from) filters.from = new Date(from as string);
+      if (to) filters.to = new Date(to as string);
+      const movements = await FinancialsService.getAllCashMovements(filters);
+      res.json(movements);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  }
+
+  static async getCashMovementById(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const movement = await FinancialsService.getCashMovementById(Number(id));
+      if (!movement) return res.status(404).json({ error: 'Movimento non trovato' });
+      res.json(movement);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  }
+
+  static async updateCashMovement(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const movement = await FinancialsService.updateCashMovement(Number(id), req.body);
+      res.json(movement);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  static async deleteCashMovement(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      await FinancialsService.deleteCashMovement(Number(id));
+      res.status(204).send();
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  // CashShift
+  static async createCashShift(req: Request, res: Response) {
+    try {
+      const shift = await FinancialsService.createCashShift(req.body);
+      res.status(201).json(shift);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  static async getAllCashShifts(req: Request, res: Response) {
+    try {
+      const { openedById, closedById, from, to } = req.query;
+      const filters: any = {};
+      if (openedById) filters.openedById = Number(openedById);
+      if (closedById) filters.closedById = Number(closedById);
+      if (from) filters.from = new Date(from as string);
+      if (to) filters.to = new Date(to as string);
+      const shifts = await FinancialsService.getAllCashShifts(filters);
+      res.json(shifts);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  }
+
+  static async getCashShiftById(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const shift = await FinancialsService.getCashShiftById(Number(id));
+      if (!shift) return res.status(404).json({ error: 'Turno di cassa non trovato' });
+      res.json(shift);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  }
+
+  static async updateCashShift(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const shift = await FinancialsService.updateCashShift(Number(id), req.body);
+      res.json(shift);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  static async closeCashShift(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const { closedById, closingAmount, notes } = req.body;
+      const shift = await FinancialsService.closeCashShift(Number(id), Number(closedById), Number(closingAmount), notes);
+      res.json(shift);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  static async deleteCashShift(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      await FinancialsService.deleteCashShift(Number(id));
+      res.status(204).send();
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  // FinancialReport
+  static async createFinancialReport(req: Request, res: Response) {
+    try {
+      const report = await FinancialsService.createFinancialReport(req.body);
+      res.status(201).json(report);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+
+  static async getAllFinancialReports(req: Request, res: Response) {
+    try {
+      const { type, period, from, to } = req.query;
+      const filters: any = {};
+      if (type) filters.type = type;
+      if (period) filters.period = period as string;
+      if (from) filters.from = new Date(from as string);
+      if (to) filters.to = new Date(to as string);
+      const reports = await FinancialsService.getAllFinancialReports(filters);
+      res.json(reports);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  }
+
+  static async getFinancialReportById(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      const report = await FinancialsService.getFinancialReportById(Number(id));
+      if (!report) return res.status(404).json({ error: 'Report non trovato' });
+      res.json(report);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  }
+
+  static async deleteFinancialReport(req: Request, res: Response) {
+    try {
+      const { id } = req.params;
+      await FinancialsService.deleteFinancialReport(Number(id));
+      res.status(204).send();
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  }
+}

--- a/backend/src/modules/financials/routes/financialsRoutes.ts
+++ b/backend/src/modules/financials/routes/financialsRoutes.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { FinancialsController } from '../controllers/financialsController';
+import {
+  createCashMovementSchema,
+  updateCashMovementSchema,
+  createCashShiftSchema,
+  updateCashShiftSchema,
+  closeCashShiftSchema,
+  createFinancialReportSchema,
+  updateFinancialReportSchema,
+  zodValidate,
+} from '../validators/financialsValidator';
+
+const router = Router();
+
+// CashMovement
+router.post('/movements', zodValidate(createCashMovementSchema), FinancialsController.createCashMovement);
+router.get('/movements', FinancialsController.getAllCashMovements);
+router.get('/movements/:id', FinancialsController.getCashMovementById);
+router.put('/movements/:id', zodValidate(updateCashMovementSchema), FinancialsController.updateCashMovement);
+router.delete('/movements/:id', FinancialsController.deleteCashMovement);
+
+// CashShift
+router.post('/shifts', zodValidate(createCashShiftSchema), FinancialsController.createCashShift);
+router.get('/shifts', FinancialsController.getAllCashShifts);
+router.get('/shifts/:id', FinancialsController.getCashShiftById);
+router.put('/shifts/:id', zodValidate(updateCashShiftSchema), FinancialsController.updateCashShift);
+router.post('/shifts/:id/close', zodValidate(closeCashShiftSchema), FinancialsController.closeCashShift);
+router.delete('/shifts/:id', FinancialsController.deleteCashShift);
+
+// FinancialReport
+router.post('/reports', zodValidate(createFinancialReportSchema), FinancialsController.createFinancialReport);
+router.get('/reports', FinancialsController.getAllFinancialReports);
+router.get('/reports/:id', FinancialsController.getFinancialReportById);
+router.delete('/reports/:id', FinancialsController.deleteFinancialReport);
+
+export default router;

--- a/backend/src/modules/financials/services/financialsService.ts
+++ b/backend/src/modules/financials/services/financialsService.ts
@@ -1,0 +1,131 @@
+import { PrismaClient, CashMovementType, ReportType } from '../../../generated/prisma/client';
+
+const prisma = new PrismaClient();
+
+export class FinancialsService {
+  // CashMovement CRUD
+  static async createCashMovement(data: any) {
+    return prisma.cashMovement.create({ data });
+  }
+
+  static async getAllCashMovements(filters: { type?: CashMovementType; userId?: number; shiftId?: number; from?: Date; to?: Date } = {}) {
+    const where: any = {};
+    if (filters.type) where.type = filters.type;
+    if (filters.userId) where.userId = filters.userId;
+    if (filters.shiftId) where.shiftId = filters.shiftId;
+    if (filters.from) where.createdAt = { ...(where.createdAt || {}), gte: filters.from };
+    if (filters.to) where.createdAt = { ...(where.createdAt || {}), lte: filters.to };
+    return prisma.cashMovement.findMany({
+      where,
+      include: {
+        user: true,
+        shift: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  static async getCashMovementById(id: number) {
+    return prisma.cashMovement.findUnique({
+      where: { id },
+      include: { user: true, shift: true },
+    });
+  }
+
+  static async updateCashMovement(id: number, data: any) {
+    return prisma.cashMovement.update({
+      where: { id },
+      data,
+    });
+  }
+
+  static async deleteCashMovement(id: number) {
+    return prisma.cashMovement.delete({
+      where: { id },
+    });
+  }
+
+  // CashShift CRUD
+  static async createCashShift(data: any) {
+    return prisma.cashShift.create({ data });
+  }
+
+  static async getAllCashShifts(filters: { openedById?: number; closedById?: number; from?: Date; to?: Date } = {}) {
+    const where: any = {};
+    if (filters.openedById) where.openedById = filters.openedById;
+    if (filters.closedById) where.closedById = filters.closedById;
+    if (filters.from) where.openedAt = { ...(where.openedAt || {}), gte: filters.from };
+    if (filters.to) where.openedAt = { ...(where.openedAt || {}), lte: filters.to };
+    return prisma.cashShift.findMany({
+      where,
+      include: {
+        openedBy: true,
+        closedBy: true,
+        movements: true,
+      },
+      orderBy: { openedAt: 'desc' },
+    });
+  }
+
+  static async getCashShiftById(id: number) {
+    return prisma.cashShift.findUnique({
+      where: { id },
+      include: { openedBy: true, closedBy: true, movements: true },
+    });
+  }
+
+  static async updateCashShift(id: number, data: any) {
+    return prisma.cashShift.update({
+      where: { id },
+      data,
+    });
+  }
+
+  static async closeCashShift(id: number, closedById: number, closingAmount: number, notes?: string) {
+    const data: any = {
+      closedById,
+      closedAt: new Date(),
+      closingAmount,
+    };
+    if (notes !== undefined) data.notes = notes;
+    return prisma.cashShift.update({
+      where: { id },
+      data,
+    });
+  }
+
+  static async deleteCashShift(id: number) {
+    return prisma.cashShift.delete({
+      where: { id },
+    });
+  }
+
+  // FinancialReport CRUD
+  static async createFinancialReport(data: any) {
+    return prisma.financialReport.create({ data });
+  }
+
+  static async getAllFinancialReports(filters: { type?: ReportType; period?: string; from?: Date; to?: Date } = {}) {
+    const where: any = {};
+    if (filters.type) where.type = filters.type;
+    if (filters.period) where.period = filters.period;
+    if (filters.from) where.startDate = { ...(where.startDate || {}), gte: filters.from };
+    if (filters.to) where.endDate = { ...(where.endDate || {}), lte: filters.to };
+    return prisma.financialReport.findMany({
+      where,
+      orderBy: { generatedAt: 'desc' },
+    });
+  }
+
+  static async getFinancialReportById(id: number) {
+    return prisma.financialReport.findUnique({
+      where: { id },
+    });
+  }
+
+  static async deleteFinancialReport(id: number) {
+    return prisma.financialReport.delete({
+      where: { id },
+    });
+  }
+}

--- a/backend/src/modules/financials/validators/financialsValidator.ts
+++ b/backend/src/modules/financials/validators/financialsValidator.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { Request, Response, NextFunction } from 'express';
+
+export const createCashMovementSchema = z.object({
+  type: z.enum(['OPEN', 'CLOSE', 'IN', 'OUT', 'RECONCILIATION', 'ADJUSTMENT']),
+  amount: z.number().min(0.01),
+  description: z.string().max(500).optional(),
+  userId: z.number().int().min(1).optional(),
+  shiftId: z.number().int().min(1).optional(),
+});
+
+export const updateCashMovementSchema = createCashMovementSchema.partial();
+
+export const createCashShiftSchema = z.object({
+  openedById: z.number().int().min(1),
+  openingAmount: z.number().min(0),
+  notes: z.string().max(500).optional(),
+});
+
+export const updateCashShiftSchema = createCashShiftSchema.partial();
+
+export const closeCashShiftSchema = z.object({
+  closedById: z.number().int().min(1),
+  closingAmount: z.number().min(0),
+  notes: z.string().max(500).optional(),
+});
+
+export const createFinancialReportSchema = z.object({
+  type: z.enum(['X', 'Z', 'SUMMARY', 'DETAILED', 'EXPORT']),
+  period: z.string().min(2),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  data: z.any(),
+});
+
+export const updateFinancialReportSchema = createFinancialReportSchema.partial();
+
+export function zodValidate(schema: z.ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      return res.status(400).json({ error: result.error.issues });
+    }
+    next();
+  };
+}


### PR DESCRIPTION
- Refactor schema Prisma: aggiunti modelli CashMovement, CashShift, FinancialReport e relazioni inverse
- Implementati CRUD completi per movimenti e turni di cassa
- Creati endpoint per apertura/chiusura cassa, cash in/out, reconciliation, report giornalieri
- Aggiunti filtri avanzati per data, utente, tipo movimento
- Validazione input con Zod su tutti i flussi
- Statistiche e reportistica base disponibili
- Testati tutti gli endpoint su Postman, validato funzionamento